### PR TITLE
Allow JWTs to contain non-string fields.

### DIFF
--- a/jose/jose.go
+++ b/jose/jose.go
@@ -64,7 +64,7 @@ const (
 	EncA256GCM      = "A256GCM"
 )
 
-type JOSEHeader map[string]string
+type JOSEHeader map[string]interface{}
 
 func (j JOSEHeader) Validate() error {
 	if _, exists := j[HeaderKeyAlgorithm]; !exists {

--- a/jose/jwt.go
+++ b/jose/jwt.go
@@ -42,7 +42,11 @@ func NewJWT(header JOSEHeader, claims Claims) (jwt JWT, err error) {
 
 func (j *JWT) KeyID() (string, bool) {
 	kID, ok := j.Header[HeaderKeyID]
-	return kID, ok
+	if !ok {
+		return "", false
+	}
+	kIDStr, ok := kID.(string)
+	return kIDStr, ok
 }
 
 func (j *JWT) Claims() (Claims, error) {


### PR DESCRIPTION
Trying to unpack a JWT containing an object field ("jwk") seems to fail
right now. This is because this code doesn't use an explicit struct to
unpack the JSON, but wants to unpack it into a map.

Change this code to be a bit more lenient by unpacking into a map of
empty interfaces. Convert values to strings when needed.