### PR TITLE
oauth2: set client secret in RequestToken body only when needed

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -93,7 +93,10 @@ func expires(date, expires string) (time.Duration, bool, error) {
 
 	te, err := time.Parse(time.RFC1123, expires)
 	if err != nil {
-		return 0, false, err
+		// according to https://tools.ietf.org/html/rfc2616#section-14.21
+		// clients MUST treat unparseable dates as "already expired"
+		// (but not an error)
+		return 0, false, nil
 	}
 
 	td, err := time.Parse(time.RFC1123, date)

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -275,7 +275,7 @@ func (c *Client) RequestToken(grantType, value string) (result TokenResponse, er
 		return
 	}
 
-	debug(httputil.DumpRequestOut(request, true))
+	debug(httputil.DumpRequestOut(req, true))
 
 	resp, err := c.hc.Do(req)
 	if err != nil {

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -3,10 +3,12 @@ package oauth2
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"fmt"
 	"io/ioutil"
 	"mime"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"sort"
 	"strconv"
@@ -273,11 +275,15 @@ func (c *Client) RequestToken(grantType, value string) (result TokenResponse, er
 		return
 	}
 
+	debug(httputil.DumpRequestOut(request, true))
+
 	resp, err := c.hc.Do(req)
 	if err != nil {
 		return
 	}
 	defer resp.Body.Close()
+	
+	debug(httputil.DumpResponse(resp, true))
 
 	return parseTokenResponse(resp)
 }
@@ -414,3 +420,12 @@ func ParseAuthCodeRequest(q url.Values) (AuthCodeRequest, error) {
 
 	return acr, err
 }
+
+func debug(data []byte, err error) {
+    if err == nil {
+        fmt.Printf("%s\n\n", data)
+    } else {
+        log.Fatalf("%s\n\n", err)
+    }
+}
+

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -257,7 +257,7 @@ func (c *Client) RequestToken(grantType, value string) (result TokenResponse, er
 	v := c.commonURLValues()
 
 	v.Set("grant_type", grantType)
-	v.Set("client_secret", c.creds.Secret)
+
 	switch grantType {
 	case GrantTypeAuthCode:
 		v.Set("code", value)

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -194,9 +194,7 @@ func (c *Client) newAuthenticatedRequest(urlToken string, values url.Values) (*h
 		if err != nil {
 			return nil, err
 		}
-		encodedID := url.QueryEscape(c.creds.ID)
-		encodedSecret := url.QueryEscape(c.creds.Secret)
-		req.SetBasicAuth(encodedID, encodedSecret)
+		req.SetBasicAuth(c.creds.ID, c.creds.Secret)
 	default:
 		panic("misconfigured client: auth method not supported")
 	}

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -3,12 +3,10 @@ package oauth2
 import (
 	"encoding/json"
 	"errors"
-	"log"
 	"fmt"
 	"io/ioutil"
 	"mime"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"sort"
 	"strconv"
@@ -273,15 +271,11 @@ func (c *Client) RequestToken(grantType, value string) (result TokenResponse, er
 		return
 	}
 
-	debug(httputil.DumpRequestOut(req, true))
-
 	resp, err := c.hc.Do(req)
 	if err != nil {
 		return
 	}
 	defer resp.Body.Close()
-	
-	debug(httputil.DumpResponse(resp, true))
 
 	return parseTokenResponse(resp)
 }
@@ -417,13 +411,5 @@ func ParseAuthCodeRequest(q url.Values) (AuthCodeRequest, error) {
 	}()
 
 	return acr, err
-}
-
-func debug(data []byte, err error) {
-    if err == nil {
-        fmt.Printf("%s\n\n", data)
-    } else {
-        log.Fatalf("%s\n\n", err)
-    }
 }
 


### PR DESCRIPTION
The client secret should only be part of the request body with
AuthMethodClientSecretPost, not with AuthMethodClientSecretBasic.

Some token endpoints are confused with a client secret in POST body _and_ a standard basic auth header, especially if they only support basic auth.