### PR TITLE
Remove client_secret POST parameter for basic auth method

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -257,7 +257,6 @@ func (c *Client) RequestToken(grantType, value string) (result TokenResponse, er
 	v := c.commonURLValues()
 
 	v.Set("grant_type", grantType)
-	v.Set("client_secret", c.creds.Secret)
 	switch grantType {
 	case GrantTypeAuthCode:
 		v.Set("code", value)


### PR DESCRIPTION
Fix for https://github.com/gambol99/keycloak-proxy/issues/336
Partial implementation of https://github.com/gambol99/go-oidc/pull/2

`func newAuthenticatedRequest` already handles token endpoint auth method properly, so creating of POST `client_secret` parameter here is not correct.

The change has been successfully tested (gambol99/keycloak-proxy was able to exchange code for the access token) with:
- corporate IdP (source code is not public), which has a problem with current mixed auth methods
- Keycloak IdP
- Google IdP

CC: @shyamz-22, @janiwe  